### PR TITLE
add created_at and updated_at timestamp fields to the database tables

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -17,8 +17,6 @@ export default function Home() {
 
   const screenToDisplay = loading ? (
     <div>Loading...</div>
-  ) : !moduleData || moduleData.length === 0 ? (
-    <div>No modules available.</div>
   ) : (
     <FormsSection moduleList={moduleData} setModuleList={setModuleData} loading={loading} />
   );

--- a/backend/db/scripts/reset-database.js
+++ b/backend/db/scripts/reset-database.js
@@ -13,6 +13,8 @@ async function resetDatabase() {
     await pool.query(`
         CREATE TABLE users (
         id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         user_name VARCHAR(25) NOT NULL,
         email VARCHAR(50) NOT NULL,
         password VARCHAR(72) NOT NULL,
@@ -24,6 +26,8 @@ async function resetDatabase() {
     await pool.query(`
             CREATE TABLE modules (
             id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             user_id INT REFERENCES users(id),
             module_name VARCHAR(50) NOT NULL,
             description VARCHAR(255) NOT NULL
@@ -34,6 +38,8 @@ async function resetDatabase() {
     await pool.query(`
             CREATE TABLE learnings (
             id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             learning_name VARCHAR(50) NOT NULL,
             module_id INT REFERENCES modules(id),
             user_id INT REFERENCES users(id),


### PR DESCRIPTION
This pull request includes changes to improve the database schema by adding timestamp fields for tracking creation and updates, and to simplify the frontend logic for displaying content based on the loading state and available data.

### Database schema improvements:
* Added `created_at` and `updated_at` timestamp fields with default values of `NOW()` to the `users` table in `resetDatabase` script.
* Added `created_at` and `updated_at` timestamp fields with default values of `NOW()` to the `modules` table in `resetDatabase` script.
* Added `created_at` and `updated_at` timestamp fields with default values of `NOW()` to the `learnings` table in `resetDatabase` script.

### Frontend logic simplification:
* Removed the conditional check for empty `moduleData` in `Home` component, simplifying the `screenToDisplay` logic.