### PR TITLE
Refactor the newlearningform to leverage new React 19 functionality

### DIFF
--- a/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
+++ b/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
@@ -53,7 +53,7 @@ export default function NewLearningForm({ moduleList, loading }) {
           />
         </label>
         <label className={styles.formLabel} htmlFor="moduleId">
-          For which module?S
+          For which module?
           <select
             name="moduleId"
             id="moduleId"
@@ -64,13 +64,18 @@ export default function NewLearningForm({ moduleList, loading }) {
             {loading ? (
               <option value="loading">Loading list...</option>
             ) : (
-              moduleList.map((module) => {
-                return (
-                  <option key={module.id} value={module.id}>
-                    {module.module_name}
-                  </option>
-                );
-              })
+              <>
+                <option disabled value="">
+                  Select a module...
+                </option>
+                {moduleList.map((module) => {
+                  return (
+                    <option key={module.id} value={module.id}>
+                      {module.module_name}
+                    </option>
+                  );
+                })}
+              </>
             )}
           </select>
         </label>

--- a/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
+++ b/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useActionState } from "react";
+import { useContext, useActionState } from "react";
 import styles from "../NewForm.module.css";
 import { AuthContext } from "@/app/context/authContext";
 
@@ -22,7 +22,7 @@ export default function NewLearningForm({ moduleList, loading }) {
       if (!response.ok)
         return {
           type: "error",
-          message: "there was an error while creating your new password",
+          message: "there was an error while creating your new learning entry",
         };
 
       const jsonResponse = await response.json();

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,3 +23,7 @@ body {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
   border-radius: 0.5rem;
 }
+
+.error {
+  color: red;
+}


### PR DESCRIPTION
This PR refactored the new learning form to use useActionState instead of the controlled handleChange way of submitting forms.
It also include an improvement to the select dropdown for modules so that a value has to be selected
And added a global error class to complement the error message added as part of the useActionState change