### PR TITLE
increase max pw length from 16 to 32 to accomadate password generators

### DIFF
--- a/app/routes/auth/page.js
+++ b/app/routes/auth/page.js
@@ -82,7 +82,7 @@ export default function Auth() {
       return {
         type: "error",
         message:
-          "Password must be 8-16 characters with at least one uppercase letter, one lowercase letter, and one number",
+          "Password must be 8-32 characters with at least one uppercase letter, one lowercase letter, and one number",
       };
     }
 

--- a/app/utils/passwordValidation.js
+++ b/app/utils/passwordValidation.js
@@ -1,4 +1,4 @@
 export default function validatePassword(password) {
-  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,16}$/;
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$/;
   return passwordRegex.test(password);
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -42,7 +42,7 @@ router.post("/signup", async (req, res) => {
     if (!validatePassword(password)) {
       return res.status(400).json({
         message:
-          "Password must be 8-16 characters with at least one uppercase letter, one lowercase letter, and one number",
+          "Password must be 8-32 characters with at least one uppercase letter, one lowercase letter, and one number",
         type: "error",
       });
     }

--- a/backend/utils/passwordValidation.js
+++ b/backend/utils/passwordValidation.js
@@ -1,4 +1,4 @@
 export default function validatePassword(password) {
-  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,16}$/;
+  const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,32}$/;
   return passwordRegex.test(password);
 }


### PR DESCRIPTION
This pull request updates the password validation logic across both the frontend and backend to allow passwords between 8 and 32 characters, instead of the previous limit of 8 to 16 characters. The changes ensure consistency in validation messages and logic throughout the application.

### Frontend Changes:
* Updated the password validation error message in `app/routes/auth/page.js` to reflect the new 8-32 character requirement.
* Modified the `validatePassword` function in `app/utils/passwordValidation.js` to update the regex for the new password length range.

### Backend Changes:
* Updated the password validation error message in the `/signup` route in `backend/routes/auth.js` to match the new 8-32 character requirement.
* Modified the `validatePassword` function in `backend/utils/passwordValidation.js` to update the regex for the new password length range.