### PR TITLE
Add delete module functionality

### DIFF
--- a/app/components/ModuleLearnings/ModuleLearnings.jsx
+++ b/app/components/ModuleLearnings/ModuleLearnings.jsx
@@ -2,14 +2,25 @@
 
 import styles from "./ModuleLearning.module.css";
 import { useContext, useState, useActionState } from "react";
+import { useRouter } from "next/navigation";
 import { ContentContext } from "@/app/context/contentContext";
 import Modal from "../Modal/Modal";
 import NewLearningForm from "../FormsSections/NewLearningForm/NewLearningForm";
 import LearningList from "../LearningList/LearningList";
 
 export default function ModuleLearnings({ moduleId }) {
-  const { moduleData, updateModule, learningData, loading } = useContext(ContentContext);
+  const router = useRouter();
+  const { moduleData, updateModule, deleteModule, learningData, loading } =
+    useContext(ContentContext);
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const deleteButtonStyle = {
+    backgroundColor: "#c23333",
+    color: "#fff",
+    fontWeight: "400",
+    border: "1px solid #000",
+  };
 
   const currentModule = moduleData.find((module) => module.id === moduleId);
   const moduleLearningsArray = learningData.filter((learning) => learning.module_id === moduleId);
@@ -35,11 +46,21 @@ export default function ModuleLearnings({ moduleId }) {
     }
   };
 
+  const handleDelete = async () => {
+    try {
+      await deleteModule(moduleId);
+      setIsDeleting(false);
+      router.push("/routes/dashboard");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   const [editState, editAction, editPending] = useActionState(handleEdit, null);
 
   return (
     <section className={styles.container}>
-      {loading ? (
+      {loading || !currentModule ? (
         <p>Loading</p>
       ) : isEditing ? (
         <form className={styles.editForm} action={editAction}>
@@ -64,11 +85,24 @@ export default function ModuleLearnings({ moduleId }) {
             </button>
           </div>
         </form>
+      ) : isDeleting ? (
+        <>
+          <p>Are you sure you want to delete this Module?</p>
+          <p>Once it&apos;s gone...it&apos;s gone</p>
+          <p>And so are all it&apos;s learnings</p>
+          <div className={styles.formButtons}>
+            <button style={deleteButtonStyle} onClick={handleDelete}>
+              Delete
+            </button>
+            <button onClick={() => setIsDeleting(false)}>Cancel</button>
+          </div>
+        </>
       ) : (
         <>
           <h2>{currentModule.module_name}</h2>
           <p>{currentModule.description}</p>
           <button onClick={() => setIsEditing(true)}>Edit</button>
+          <button onClick={() => setIsDeleting(true)}>Delete</button>
         </>
       )}
       <Modal title="Add a learning" openButtonText="Add a new learning" closeButtonText="Finished">

--- a/app/components/ModuleLearnings/ModuleLearnings.jsx
+++ b/app/components/ModuleLearnings/ModuleLearnings.jsx
@@ -89,7 +89,7 @@ export default function ModuleLearnings({ moduleId }) {
         <>
           <p>Are you sure you want to delete this Module?</p>
           <p>Once it&apos;s gone...it&apos;s gone</p>
-          <p>And so are all it&apos;s learnings</p>
+          <p>And so are all its learnings</p>
           <div className={styles.formButtons}>
             <button style={deleteButtonStyle} onClick={handleDelete}>
               Delete

--- a/app/context/contentContext.js
+++ b/app/context/contentContext.js
@@ -133,6 +133,9 @@ export function ContentProvider({ children }) {
       setModuleData((prevModuleData) => {
         return prevModuleData.filter((module) => module.id !== moduleId);
       });
+      setLearningData((prevLearningData) => {
+        return prevLearningData.filter((learning) => learning.module_id !== moduleId);
+      });
     } catch (error) {
       console.error("Error deleting module:", error);
       setError("Failed to delete the module. Please try again.");

--- a/app/context/contentContext.js
+++ b/app/context/contentContext.js
@@ -127,7 +127,7 @@ export function ContentProvider({ children }) {
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        const errorMessage = errorData.message || "There was an error while deleting your module.";
+        const errorMessage = errorData.payload || "There was an error while deleting your module.";
         throw new Error(errorMessage);
       }
       setModuleData((prevModuleData) => {

--- a/app/context/contentContext.js
+++ b/app/context/contentContext.js
@@ -105,6 +105,42 @@ export function ContentProvider({ children }) {
     );
   };
 
+  const deleteModule = async (moduleId) => {
+    setLoading(true);
+    let accessToken = await getAccessToken();
+    if (!accessToken) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/api/modules/${moduleId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+        }
+      );
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMessage = errorData.message || "There was an error while deleting your module.";
+        throw new Error(errorMessage);
+      }
+      setModuleData((prevModuleData) => {
+        return prevModuleData.filter((module) => module.id !== moduleId);
+      });
+    } catch (error) {
+      console.error("Error deleting module:", error);
+      setError("Failed to delete the module. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const fetchLearnings = async (accessToken) => {
     const response = await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/learnings`, {
       method: "GET",
@@ -184,6 +220,7 @@ export function ContentProvider({ children }) {
     updateModule,
     updateLearning,
     deleteLearning,
+    deleteModule,
     fetchAllData,
     loading,
     error,

--- a/app/routes/modules/[slug]/page.js
+++ b/app/routes/modules/[slug]/page.js
@@ -3,11 +3,11 @@ import ProtectedRoute from "../../ProtectedRoute";
 
 export default async function Modules({ params }) {
   const { slug } = await params;
-  const [id] = slug;
+  const id = Number(slug);
 
   return (
     <ProtectedRoute>
-      <ModuleLearnings moduleId={Number(id)} />
+      <ModuleLearnings moduleId={id} />
     </ProtectedRoute>
   );
 }

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,7 +1,7 @@
 import express from "express";
 
 // helper imports
-import { getModules, createModule, updateModule } from "../utils/modules.js";
+import { getModules, createModule, updateModule, deleteModule } from "../utils/modules.js";
 import {
   getLearnings,
   createLearning,

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -79,7 +79,7 @@ router.patch("/api/modules/:id", verifyAccess, async (req, res) => {
   }
 });
 
-// delete a module (and all it's learnings)
+// delete a module (and all its learnings)
 router.delete("/api/modules/:id", verifyAccess, async (req, res) => {
   const user = req.user;
   const moduleId = req.params.id;
@@ -96,7 +96,7 @@ router.delete("/api/modules/:id", verifyAccess, async (req, res) => {
     }
   } catch (error) {
     res.status(500).json({
-      payload: error,
+      payload: error.message || "An unexpected error occured",
     });
   }
 });

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -79,6 +79,28 @@ router.patch("/api/modules/:id", verifyAccess, async (req, res) => {
   }
 });
 
+// delete a module (and all it's learnings)
+router.delete("/api/modules/:id", verifyAccess, async (req, res) => {
+  const user = req.user;
+  const moduleId = req.params.id;
+  try {
+    const deletedModule = await deleteModule(moduleId, user.id);
+    if (deletedModule) {
+      return res.status(200).json({
+        payload: deletedModule,
+      });
+    } else {
+      return res.status(404).json({
+        payload: "You don't have access to this resource",
+      });
+    }
+  } catch (error) {
+    res.status(500).json({
+      payload: error,
+    });
+  }
+});
+
 // route handler to get all learnings for a specific user
 router.get("/api/learnings/", verifyAccess, async (req, res) => {
   const user = req.user;
@@ -150,7 +172,7 @@ router.delete("/api/learnings/:id", verifyAccess, async (req, res) => {
   const user = req.user;
   const id = req.params.id;
   if (!user) {
-    // TODO: Update all endpoints to handle falsy user
+    // TODO: Update all endpoints to handle falsy user or trust the verify access to take care of it
     return res.status(401).json({
       payload: "You don't have access to this resource",
     });

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -96,7 +96,7 @@ router.delete("/api/modules/:id", verifyAccess, async (req, res) => {
     }
   } catch (error) {
     res.status(500).json({
-      payload: error.message || "An unexpected error occured",
+      payload: error.message || "An unexpected error occurred",
     });
   }
 });

--- a/backend/utils/modules.js
+++ b/backend/utils/modules.js
@@ -72,3 +72,18 @@ export async function updateModule(module, id) {
     });
   }
 }
+
+export async function deleteModule(id, userId) {
+  const query = `DELETE FROM modules WHERE id = $1 AND user_id = $2 RETURNING *`;
+  try {
+    const result = await pool.query(query, [id, userId]);
+    return result.rows[0];
+  } catch (e) {
+    console.error("Error executing query", {
+      message: e.message,
+      stack: e.stack,
+      query,
+    });
+    throw e;
+  }
+}


### PR DESCRIPTION
This pull request introduces functionality to delete modules and their associated learnings, along with necessary frontend and backend changes to support this feature. Additionally, minor adjustments were made to improve code readability and consistency.

### Frontend Changes

* **Added delete functionality in `ModuleLearnings.jsx`:** 
  - Introduced a `handleDelete` function to delete a module and navigate back to the dashboard upon successful deletion.
  - Added UI elements (confirmation dialog and buttons) for deleting a module, including a new `deleteButtonStyle` for styling.
  - Updated `ContentContext` to include the `deleteModule` method for handling module deletions. [[1]](diffhunk://#diff-63af5839bb3f352a7fc221de82bce7d2cc7efcfe8dcd6c255c25219260f0029bR108-R146) [[2]](diffhunk://#diff-63af5839bb3f352a7fc221de82bce7d2cc7efcfe8dcd6c255c25219260f0029bR226)

* **Improved parameter handling in `page.js`:** Simplified the conversion of `slug` to a number for better readability and consistency. ([app/routes/modules/[slug]/page.jsL6-R10](diffhunk://#diff-bd5f11285997626938e6de486e9eb122be9bdf8e948d49a1df345d0b172594bcL6-R10))

### Backend Changes

* **Implemented `deleteModule` API route:** 
  - Added a new route (`DELETE /api/modules/:id`) to handle module deletions, ensuring proper user access verification.
  - Updated module utilities with a `deleteModule` function to execute the database query for module deletion.

* **Extended module imports in `routes/index.js`:** Included the `deleteModule` function in the backend routes file to support the new API endpoint.