### PR TITLE
Address issues raised in testing feedback from lkk

### DIFF
--- a/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
+++ b/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
@@ -50,7 +50,7 @@ export default function NewLearningForm() {
     <div className={styles.wide}>
       <form className={styles.siteForm} action={submitNewLearning}>
         <label className={styles.formLabel} htmlFor="learningName">
-          What did I learn?
+          What are you learning?
           <input
             type="text"
             name="learningName"
@@ -81,6 +81,7 @@ export default function NewLearningForm() {
           </select>
         </label>
         <label className={styles.formLabel} htmlFor="ragStatus">
+          Confidence level?
           <select name="ragStatus" id="ragStatus" className={styles.formInput}>
             <option value="red">Red 🔴</option>
             <option value="amber">Amber 🟠</option>
@@ -92,7 +93,7 @@ export default function NewLearningForm() {
             rows="3"
             name="learningNotes"
             id="learningNotes"
-            placeholder="Thoughts worthy of noting in terms of my learning..."
+            placeholder="Thoughts worthy of noting in terms of my learning, or plan for improving my confidence..."
             className={styles.formInput}
           ></textarea>
         </label>

--- a/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
+++ b/app/components/FormsSections/NewLearningForm/NewLearningForm.jsx
@@ -3,12 +3,12 @@ import styles from "../NewForm.module.css";
 import { AuthContext } from "@/app/context/authContext";
 import { ContentContext } from "@/app/context/contentContext";
 
-export default function NewLearningForm() {
+export default function NewLearningForm({ moduleIdProp }) {
   const { user } = useContext(AuthContext);
   const { moduleData, setLearningData, loading } = useContext(ContentContext);
   const [state, submitNewLearning, isPending] = useActionState(async (prev, formData) => {
     const learningName = formData.get("learningName");
-    const moduleId = formData.get("moduleId");
+    const moduleId = moduleIdProp ? moduleIdProp : formData.get("moduleId");
     const ragStatus = formData.get("ragStatus");
     const learningNotes = formData.get("learningNotes");
     if (!learningName || !moduleId) {
@@ -59,27 +59,29 @@ export default function NewLearningForm() {
             className={styles.formInput}
           />
         </label>
-        <label className={styles.formLabel} htmlFor="moduleId">
-          For which module?
-          <select name="moduleId" id="moduleId" className={styles.formInput} defaultValue="">
-            {loading ? (
-              <option value="loading">Loading list...</option>
-            ) : (
-              <>
-                <option disabled value="">
-                  Select a module...
-                </option>
-                {moduleData.map((module) => {
-                  return (
-                    <option key={module.id} value={module.id}>
-                      {module.module_name}
-                    </option>
-                  );
-                })}
-              </>
-            )}
-          </select>
-        </label>
+        {!moduleIdProp ? (
+          <label className={styles.formLabel} htmlFor="moduleId">
+            For which module?
+            <select name="moduleId" id="moduleId" className={styles.formInput} defaultValue="">
+              {loading ? (
+                <option value="loading">Loading list...</option>
+              ) : (
+                <>
+                  <option disabled value="">
+                    Select a module...
+                  </option>
+                  {moduleData.map((module) => {
+                    return (
+                      <option key={module.id} value={module.id}>
+                        {module.module_name}
+                      </option>
+                    );
+                  })}
+                </>
+              )}
+            </select>
+          </label>
+        ) : null}
         <label className={styles.formLabel} htmlFor="ragStatus">
           Confidence level?
           <select name="ragStatus" id="ragStatus" className={styles.formInput}>

--- a/app/components/HowToGuide/HowToGuide.jsx
+++ b/app/components/HowToGuide/HowToGuide.jsx
@@ -10,12 +10,22 @@ export default function HowToGuide() {
         <p>Here&apos;s a quick guide:</p>
         <ul>
           <li>Start on the Dashboard to select or add a module.</li>
-          <li>Click a module to view and add your learnings.</li>
+          <li>
+            Click a module to:
+            <ul>
+              <li>view and add your learnings.</li>
+              <li>edit your module info.</li>
+              <li>delete the module.</li>
+            </ul>
+          </li>
           <li>
             Use the &quot;Add a new learning&quot; button to document what you&apos;ve learned.
           </li>
+          <li>Click on a learning pill to see more info.</li>
+          <li>You can edit and delete it here as well.</li>
           <li>Use this Help icon anytime to revisit guidance.</li>
         </ul>
+        <small>I'll make this look less awful soon...</small>
       </Modal>
     </div>
   );

--- a/app/components/HowToGuide/HowToGuide.jsx
+++ b/app/components/HowToGuide/HowToGuide.jsx
@@ -25,7 +25,7 @@ export default function HowToGuide() {
           <li>You can edit and delete it here as well.</li>
           <li>Use this Help icon anytime to revisit guidance.</li>
         </ul>
-        <small>I'll make this look less awful soon...</small>
+        <small>I&apos;ll make this look less awful soon...</small>
       </Modal>
     </div>
   );

--- a/app/components/Intro/Intro.jsx
+++ b/app/components/Intro/Intro.jsx
@@ -12,7 +12,7 @@ export default function Intro() {
   return (
     <>
       <h2>Hey again {user.username}</h2>
-      <p>What are you going to focus on today</p>
+      <p>What are you going to focus on today?</p>
       <p>Or would you like to...</p>
       <Modal title="Add a Module" openButtonText="Add a new module" closeButtonText="Finished">
         <NewModuleForm />

--- a/app/components/ModuleLearnings/ModuleLearnings.jsx
+++ b/app/components/ModuleLearnings/ModuleLearnings.jsx
@@ -58,38 +58,43 @@ export default function ModuleLearnings({ moduleId }) {
 
   const [editState, editAction, editPending] = useActionState(handleEdit, null);
 
+  const editForm = (
+    <form className={styles.editForm} action={editAction}>
+      <input
+        className={styles.formInput}
+        name="moduleName"
+        defaultValue={currentModule.module_name}
+      />
+      <textarea
+        className={styles.formInput}
+        rows={3}
+        name="description"
+        defaultValue={currentModule.description}
+      ></textarea>
+      <input name="moduleId" type="hidden" value={currentModule.id} />
+      <div className={styles.formButtons}>
+        <button type="submit" disabled={editPending}>
+          {editPending ? "Saving..." : "Save"}
+        </button>
+        <button type="button" onClick={() => setIsEditing(false)}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+
   return (
     <section className={styles.container}>
       {loading || !currentModule ? (
         <p>Loading</p>
       ) : isEditing ? (
-        <form className={styles.editForm} action={editAction}>
-          <input
-            className={styles.formInput}
-            name="moduleName"
-            defaultValue={currentModule.module_name}
-          />
-          <textarea
-            className={styles.formInput}
-            rows={3}
-            name="description"
-            defaultValue={currentModule.description}
-          ></textarea>
-          <input name="moduleId" type="hidden" value={currentModule.id} />
-          <div className={styles.formButtons}>
-            <button type="submit" disabled={editPending}>
-              {editPending ? "Saving..." : "Save"}
-            </button>
-            <button type="button" onClick={() => setIsEditing(false)}>
-              Cancel
-            </button>
-          </div>
-        </form>
+        editForm
       ) : isDeleting ? (
         <>
+          <h2>{currentModule.module_name}</h2>
           <p>Are you sure you want to delete this Module?</p>
-          <p>Once it&apos;s gone...it&apos;s gone</p>
-          <p>And so are all its learnings</p>
+          <p>Once it&apos;s gone...it&apos;s gone.</p>
+          <p>And so are all its learnings.</p>
           <div className={styles.formButtons}>
             <button style={deleteButtonStyle} onClick={handleDelete}>
               Delete
@@ -101,16 +106,22 @@ export default function ModuleLearnings({ moduleId }) {
         <>
           <h2>{currentModule.module_name}</h2>
           <p>{currentModule.description}</p>
-          <button onClick={() => setIsEditing(true)}>Edit</button>
-          <button onClick={() => setIsDeleting(true)}>Delete</button>
+          <div className={styles.formButtons}>
+            <button onClick={() => setIsEditing(true)}>Edit</button>
+            <button onClick={() => setIsDeleting(true)}>Delete</button>
+          </div>
+          <Modal
+            title="Add a learning"
+            openButtonText="Add a new learning"
+            closeButtonText="Finished"
+          >
+            <NewLearningForm moduleIdProp={currentModule.id} />
+          </Modal>
+          <div>
+            <LearningList learningData={moduleLearningsArray} loading={loading} />
+          </div>
         </>
       )}
-      <Modal title="Add a learning" openButtonText="Add a new learning" closeButtonText="Finished">
-        <NewLearningForm moduleIdProp={currentModule.id} />
-      </Modal>
-      <div>
-        <LearningList learningData={moduleLearningsArray} loading={loading} />
-      </div>
     </section>
   );
 }

--- a/app/components/ModuleLearnings/ModuleLearnings.jsx
+++ b/app/components/ModuleLearnings/ModuleLearnings.jsx
@@ -106,7 +106,7 @@ export default function ModuleLearnings({ moduleId }) {
         </>
       )}
       <Modal title="Add a learning" openButtonText="Add a new learning" closeButtonText="Finished">
-        <NewLearningForm />
+        <NewLearningForm moduleIdProp={currentModule.id} />
       </Modal>
       <div>
         <LearningList learningData={moduleLearningsArray} loading={loading} />


### PR DESCRIPTION
This pull request introduces enhancements to several components in the application, focusing on improving user experience, adding conditional logic, and refining the interface for module and learning management. The most significant changes include updates to the `NewLearningForm` component to support external module IDs, improvements to the `ModuleLearnings` component for better editing and deletion workflows, and updates to the `HowToGuide` and `Intro` components for clearer guidance and polished text.

### Updates to `NewLearningForm`:
* Added support for passing a `moduleIdProp` to the component, allowing external module IDs to be used instead of requiring user input. Conditional rendering ensures the module selection dropdown is hidden when `moduleIdProp` is provided. [[1]](diffhunk://#diff-60c65b24df408891ca501f7a085d82dff7393b2e7271778cfde3c6dcc26cc4baL6-R11) [[2]](diffhunk://#diff-60c65b24df408891ca501f7a085d82dff7393b2e7271778cfde3c6dcc26cc4baR62) [[3]](diffhunk://#diff-60c65b24df408891ca501f7a085d82dff7393b2e7271778cfde3c6dcc26cc4baR84-R86)
* Updated form labels and placeholders for improved clarity and user guidance, such as changing "What did I learn?" to "What are you learning?" and refining the placeholder text for learning notes. [[1]](diffhunk://#diff-60c65b24df408891ca501f7a085d82dff7393b2e7271778cfde3c6dcc26cc4baL53-R53) [[2]](diffhunk://#diff-60c65b24df408891ca501f7a085d82dff7393b2e7271778cfde3c6dcc26cc4baL95-R98)

### Enhancements to `ModuleLearnings`:
* Refactored the component to separate the edit form into its own variable (`editForm`), improving readability and modularity.
* Added conditional rendering for the delete confirmation workflow, including a clear message and buttons for editing and deleting modules.
* Updated the "Add a learning" modal to pass the current module's ID (`moduleIdProp`) to the `NewLearningForm` component, streamlining the learning addition process.

### Improvements to `HowToGuide`:
* Expanded guidance to include instructions for editing and deleting modules, and for managing individual learnings, making the guide more comprehensive. Added a note for future visual improvements.

### Minor text fixes in `Intro`:
* Corrected punctuation in the introductory text for better readability.